### PR TITLE
Added check when writing the Application Descriptor file

### DIFF
--- a/utils/applicationDescriptorUtils.groovy
+++ b/utils/applicationDescriptorUtils.groovy
@@ -63,12 +63,14 @@ def readApplicationDescriptor(File yamlFile){
  */
 def writeApplicationDescriptor(File yamlFile, ApplicationDescriptor applicationDescriptor){
 	// Sort source groups and files by name before writing to YAML file
-	applicationDescriptor.sources.sort {
-		it.name
-	}
-	applicationDescriptor.sources.each() { source ->
-		source.files.sort {
+	if (applicationDescriptor.sources) {
+		applicationDescriptor.sources.sort {
 			it.name
+		}
+		applicationDescriptor.sources.each() { source ->
+			source.files.sort {
+				it.name
+			}
 		}
 	} 
 


### PR DESCRIPTION
Added a check to avoid performing the sorting of sources entries in the Application Descriptor, when there is no source defined. This is just to reinforce checks in the processing.
Likely, if there is no source associated to an application, it means the mapping is probably wrong.