### PR TITLE
Additional error message when scan fails

### DIFF
--- a/scanApplication.groovy
+++ b/scanApplication.groovy
@@ -86,8 +86,13 @@ def scanFiles(fileList) {
 	fileList.each{ file ->
 		DependencyScanner scanner = new DependencyScanner()
 		logger.logMessage "\t Scanning file $file "
-		logicalFile = scanner.scan(file, props.workspace)
-		logicalFiles.add(logicalFile)
+		try {
+			logicalFile = scanner.scan(file, props.workspace)
+			logicalFiles.add(logicalFile)
+		} catch (Exception e) {
+			logger.logMessage "\t\tSomething went wrong when scanning this file."
+			logger.logMessage(e.getMessage())
+		}
 	}
 	return logicalFiles
 }

--- a/utils/applicationDescriptorUtils.groovy
+++ b/utils/applicationDescriptorUtils.groovy
@@ -63,12 +63,14 @@ def readApplicationDescriptor(File yamlFile){
  */
 def writeApplicationDescriptor(File yamlFile, ApplicationDescriptor applicationDescriptor){
 	// Sort source groups and files by name before writing to YAML file
-	applicationDescriptor.sources.sort {
-		it.name
-	}
-	applicationDescriptor.sources.each() { source ->
-		source.files.sort {
+	if (applicationDescriptor.sources) {
+		applicationDescriptor.sources.sort {
 			it.name
+		}
+		applicationDescriptor.sources.each() { source ->
+			source.files.sort {
+				it.name
+			}
 		}
 	} 
 


### PR DESCRIPTION
When the DBB scanner fails, it is difficult to identify which file is causing a problem. With this enhancement, an error message is displayed for the file scanned.
Additional, it contains a fix for when writing an Application Descriptor which doesn't contain any source groups.