### PR TITLE
Generate/update Application Descriptor for applications managed in git

### DIFF
--- a/0-environment.sh
+++ b/0-environment.sh
@@ -8,7 +8,8 @@
 # Contract with IBM Corp. 
 #*******************************************************************************
 
-export DBB_MODELER_HOME=/u/mdalbin/Migration-Modeler
-export DBB_MODELER_APPCONFIGS=$DBB_MODELER_HOME/work-configs
-export DBB_MODELER_APPLICATIONS=$DBB_MODELER_HOME/work-applications
-export DBB_MODELER_LOGS=$DBB_MODELER_HOME/work-logs
+export DBB_MODELER_HOME=/u/dbehm/git/dbb-git-migration-modeler
+export DBB_MODELER_APPCONFIGS=/u/dbehm/git/dbb-git-migration-modeler-work/work-configs
+export DBB_MODELER_APPLICATIONS=/u/dbehm/git/dbb-git-migration-modeler-work/work-applications
+export DBB_MODELER_LOGS=/u/dbehm/git/dbb-git-migration-modeler-work/work-logs
+export DBB_MODELER_METADATA_STORE=/u/dbehm/git/dbb-git-migration-modeler-work/work-metadatastore

--- a/3-classify.sh
+++ b/3-classify.sh
@@ -14,34 +14,46 @@ then
 else
 	# Environment variables setup
 	. ./0-environment.sh
+	
+	# Build Metadatastore
+	if [ -d $DBB_MODELER_METADATA_STORE ] 
+    then
+        rm -rf $DBB_MODELER_METADATA_STORE
+    fi
+    
+    if [ ! -d $DBB_MODELER_METADATA_STORE ] 
+    then
+        mkdir -p $DBB_MODELER_METADATA_STORE
+    fi
 
-	cd $DBB_MODELER_APPCONFIGS
-	for mappingFile in `ls *.mapping`
+    # Scan files
+	cd $DBB_MODELER_APPLICATIONS
+	for applicationDir in `ls`
 	do
-		application=`echo $mappingFile | awk -F. '{ print $1 }'`
 		echo "*******************************************************************"
-		echo "Scan application directory $DBB_MODELER_APPLICATIONS/$application"
+		echo "Scan application directory $DBB_MODELER_APPLICATIONS/$applicationDir"
 		echo "*******************************************************************"
 		CMD="$DBB_HOME/bin/groovyz $DBB_MODELER_HOME/scanApplication.groovy \
 			-w $DBB_MODELER_APPLICATIONS \
-			-a $application \
-			-l $DBB_MODELER_LOGS/3-$application-scan.log"
+			-a $applicationDir \
+			-m $DBB_MODELER_METADATA_STORE \
+			-l $DBB_MODELER_LOGS/3-$application-scan.log"	
 		$CMD "$@"
 	done
 
-	cd $DBB_MODELER_APPCONFIGS
-	for mappingFile in `ls *.mapping`
+    cd $DBB_MODELER_APPLICATIONS
+    for applicationDir in `ls`
 	do
-		application=`echo $mappingFile | awk -F. '{ print $1 }'`
 		echo "*******************************************************************"
-		echo "Assess Include files & Programs usage for $application"
+		echo "Assess Include files & Programs usage for $applicationDir"
 		echo "*******************************************************************"
 		CMD="$DBB_HOME/bin/groovyz $DBB_MODELER_HOME/assessUsage.groovy \
 			--workspace $DBB_MODELER_APPLICATIONS \
-			--application $application \
 			--configurations $DBB_MODELER_APPCONFIGS \
+			--metadatastore $DBB_MODELER_METADATA_STORE \
+			--application $applicationDir \
 			--moveFiles \
-			--logFile $DBB_MODELER_LOGS/3-$application-assessUsage.log"
+			--logFile $DBB_MODELER_LOGS/3-$applicationDir-assessUsage.log"
 		$CMD "$@"
 	done
 fi

--- a/5-refreshApplicationDescriptors.sh
+++ b/5-refreshApplicationDescriptors.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+#*******************************************************************************
+# Licensed Materials - Property of IBM
+# (c) Copyright IBM Corporation 2018, 2024. All Rights Reserved.
+#
+# Note to U.S. Government Users Restricted Rights:
+# Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp. 
+#*******************************************************************************
+
+if [  "$DBB_HOME" = "" ]
+then
+    echo "Environment variable DBB_HOME is not set. Exiting..."
+else
+    # Environment variables setup
+    . ./0-environment.sh
+    
+    #### Build Metadatastore
+    if [ -d $DBB_MODELER_METADATA_STORE ] 
+    then
+        rm -rf $DBB_MODELER_METADATA_STORE
+    fi
+    
+    if [ ! -d $DBB_MODELER_METADATA_STORE ] 
+    then
+        mkdir -p $DBB_MODELER_METADATA_STORE
+    fi
+
+    # Scan files
+    cd $DBB_MODELER_APPLICATIONS
+    for applicationDir in `ls`
+    do
+        echo "*******************************************************************"
+        echo "Scan application directory $DBB_MODELER_APPLICATIONS/$applicationDir"
+        echo "*******************************************************************"
+        CMD="$DBB_HOME/bin/groovyz $DBB_MODELER_HOME/scanApplication.groovy \
+            -w $DBB_MODELER_APPLICATIONS \
+            -a $applicationDir \
+            -m $DBB_MODELER_METADATA_STORE \
+            -l $DBB_MODELER_LOGS/3-$application-scan.log"   
+        $CMD "$@"
+    done
+    
+    # Reset Application Descriptor
+    cd $DBB_MODELER_APPLICATIONS
+    for applicationDir in `ls`
+    do
+        echo "*******************************************************************"
+        echo "Reset Application Descriptor for $applicationDir"
+        echo "*******************************************************************"
+        CMD="$DBB_HOME/bin/groovyz $DBB_MODELER_HOME/recreateApplicationDescriptor.groovy \
+            --workspace $DBB_MODELER_APPLICATIONS \
+            --application $applicationDir \
+            --repositoryPathsMapping $DBB_MODELER_HOME/repositoryPathsMapping.yaml \
+            --logFile $DBB_MODELER_LOGS/3-$applicationDir-createApplicationDescriptor.log"
+        echo $CMD
+        $CMD "$@"
+    done
+
+    cd $DBB_MODELER_APPLICATIONS
+    for applicationDir in `ls`
+    do
+        echo "*******************************************************************"
+        echo "Assess Include files & Programs usage for $applicationDir"
+        echo "*******************************************************************"
+        CMD="$DBB_HOME/bin/groovyz $DBB_MODELER_HOME/assessUsage.groovy \
+            --workspace $DBB_MODELER_APPLICATIONS \
+            --metadatastore $DBB_MODELER_METADATA_STORE \
+            --application $applicationDir \
+            --logFile $DBB_MODELER_LOGS/3-$applicationDir-assessUsage.log"
+        $CMD "$@"
+    done
+fi

--- a/assessUsage.groovy
+++ b/assessUsage.groovy
@@ -51,9 +51,9 @@ if (props.logFile) {
 }
 
 // create metadatastore
-metadataStore = MetadataStoreFactory.createFileMetadataStore("${props.workspace}/.dbb")
+metadataStore = MetadataStoreFactory.createFileMetadataStore("${props.metadatastore}")
 if (!metadataStore) {
-	logger.logMessage("!* Error: Failed to initialize the DBB File Metatadastore at ${props.workspace}/.dbb");
+	logger.logMessage("!* Error: Failed to initialize the DBB File Metatadastore at ${props.metadatastore}");
 } 
 
 logger.logMessage("** Getting the list of files of 'Include File' type.")
@@ -334,8 +334,9 @@ def parseArgs(String[] args) {
 	def cli = new CliBuilder(usage:usage)
 	// required sandbox options
 	cli.w(longOpt:'workspace', args:1, 'Absolute path to workspace (root) directory containing all required source directories')
+	cli.d(longOpt:'metadatastore', args:1, 'Absolute path to DBB Dependency Metadatastore used by the modeler')
 	cli.a(longOpt:'application', args:1, required:true, 'Application  name.')
-	cli.c(longOpt:'configurations', args:1, required:true, 'Path of the directory containing Application Configurations YAML files.')
+	cli.c(longOpt:'configurations', args:1, required:false, 'Path of the directory containing Application Configurations YAML files.')
 	cli.m(longOpt:'moveFiles', args:0, 'Flag to move files when usage is assessed.')
 	cli.l(longOpt:'logFile', args:1, required:false, 'Relative or absolute path to an output log file')
 
@@ -345,6 +346,7 @@ def parseArgs(String[] args) {
 	}
 
 	if (opts.w) props.workspace = opts.w
+	if (opts.d) props.metadatastore = opts.d
 	if (opts.a) props.application = opts.a
 	if (opts.c) props.configurationsDirectory = opts.c
 	if (opts.m) {

--- a/recreateApplicationDescriptor.groovy
+++ b/recreateApplicationDescriptor.groovy
@@ -1,0 +1,172 @@
+/********************************************************************************
+ * Licensed Materials - Property of IBM                                          *
+ * (c) Copyright IBM Corporation 2018, 2024. All Rights Reserved.                *
+ *                                                                               *
+ * Note to U.S. Government Users Restricted Rights:                              *
+ * Use, duplication or disclosure restricted by GSA ADP Schedule                 *
+ * Contract with IBM Corp.                                                       *
+ ********************************************************************************/
+
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import groovy.util.*
+import groovy.time.*
+import groovy.cli.commons.*
+import groovy.yaml.YamlSlurper
+import java.nio.file.*
+import java.nio.file.attribute.*
+
+@Field def applicationDescriptorUtils = loadScript(new File("utils/applicationDescriptorUtils.groovy"))
+@Field def logger = loadScript(new File("utils/logger.groovy"))
+@Field repositoryPathsMapping
+
+// script properties
+@Field Properties props = new Properties()
+// Internal variables
+def applicationDescriptor
+
+/**
+ * Processing logic
+ */
+
+println("** Recreate Application Descriptor process started. ")
+
+// Parse arguments from command-line
+parseArgs(args)
+
+// Print parms
+println("** Script configuration:")
+props.each { k,v->
+	println "   $k -> $v"
+}
+
+// Handle log file
+if (props.logFile) {
+	logger.create(props.logFile)
+}
+
+// Read the repository layout mapping file
+logger.logMessage ("** Reading the Repository Layout Mapping definition. ")
+
+if (props.repositoryPathsMappingFilePath) {
+	File repositoryPathsMappingFile = new File(props.repositoryPathsMappingFilePath)
+	if (!repositoryPathsMappingFile.exists()) {
+		logger.logMessage "!* Warning: File ${props.repositoryPathsMappingFilePath} not found. Process will exit."
+		System.exit(1)
+	} else {
+		def yamlSlurper = new groovy.yaml.YamlSlurper()
+		repositoryPathsMapping = yamlSlurper.parse(repositoryPathsMappingFile)
+	}
+}
+
+// Initialize the Application Descriptor
+File applicationDescriptorFile = new File("${props.workspace}/${props.application}/${props.application}.yaml")
+if (applicationDescriptorFile.exists()) {
+	logger.logMessage("* Importing existing Application Descriptor and reset source groups, dependencies and consumers.");
+	applicationDescriptor = applicationDescriptorUtils.readApplicationDescriptor(applicationDescriptorFile)
+	applicationDescriptorUtils.resetAllSourceGroups(applicationDescriptor)
+	applicationDescriptorUtils.resetConsumersAndDependencies(applicationDescriptor)
+} else {
+	logger.logMessage("* Creating a new Application Descriptor.");
+	applicationDescriptor = applicationDescriptorUtils.createEmptyApplicationDescriptor()
+	applicationDescriptor.application = props.application
+}
+
+logger.logMessage("* Getting List of files ${props.workspace}/${props.application}");
+Set<String> fileList = getFileList("${props.workspace}/${props.application}")
+
+fileList.each() { file ->
+
+	if (!file.startsWith(".")) {
+
+		// path to look up in the repository path mapping configuration
+		def pathToLookup = file.replace(props.application, "\$application").replace(new File(file).getName(),"")
+		if (pathToLookup.endsWith('/'))
+			pathToLookup = pathToLookup.take(pathToLookup.length()-1)
+
+		// finding the repository path mapping configuration based on the relative path
+		def matchingRepositoryPath = repositoryPathsMapping.repositoryPaths.find {it ->
+			it.repositoryPath.contains(pathToLookup)
+		}
+
+		// Loop through directories and append file definitions
+		if (matchingRepositoryPath) {
+			type = "UNKNOWN" // TODO - New Service Util
+			usage = "undefined"
+			fileExtension = matchingRepositoryPath.fileExtension
+			// extract basefilename
+			fileName = new File(file).getName()
+			baseFileName = fileName.replace(".$fileExtension","")
+			repositoryPath = file.replace("/${fileName}","")
+
+			logger.logMessage("* Adding file $file to Application Descriptor into source group ${matchingRepositoryPath.sourceGroup}.");
+			
+			
+			applicationDescriptorUtils.appendFileDefinition(applicationDescriptor, matchingRepositoryPath.sourceGroup, matchingRepositoryPath.languageProcessor, matchingRepositoryPath.artifactsType, fileExtension, repositoryPath, baseFileName, type, usage)
+
+		} else {
+			logger.logMessage("*! The file ($file) did not match any rule defined in the repository path mapping configuration.");
+		}
+
+	} else {
+		// A hidden file found
+		logger.logMessage("*! A hidden file found ($file). Skipped.");
+
+	}
+
+
+}
+
+
+applicationDescriptorUtils.writeApplicationDescriptor(applicationDescriptorFile, applicationDescriptor)
+logger.logMessage("* Created Application Description file " + applicationDescriptorFile.getAbsolutePath());
+
+/**
+ * Parse CLI config
+ */
+def parseArgs(String[] args) {
+
+	String usage = 'createApplicationDescriptor.groovy [options]'
+
+	def cli = new CliBuilder(usage:usage)
+	// required sandbox options
+	cli.w(longOpt:'workspace', args:1, 'Absolute path to workspace (root) directory containing all required source directories')
+	cli.a(longOpt:'application', args:1, required:true, 'Application  name ')
+	cli.r(longOpt:'repositoryPathsMapping', args:1, required:true, 'Path to the Repository Paths Mapping file')
+	cli.l(longOpt:'logFile', args:1, required:false, 'Relative or absolute path to an output log file')
+
+	def opts = cli.parse(args)
+	if (!opts) {
+		System.exit(1)
+	}
+
+	if (opts.w) props.workspace = opts.w
+	if (opts.a) props.application = opts.a
+	if (opts.r) props.repositoryPathsMappingFilePath = opts.r
+	if (opts.l) props.logFile = opts.l
+
+}
+
+/**
+ * Returns the list of files within the directory structure 
+ * 
+ */
+
+def getFileList(String dir) {
+	Set<String> fileList = new HashSet();
+	Files.walkFileTree(Paths.get(dir), new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+					if (!Files.isDirectory(file)) {
+
+						String fileName = file.toString();
+						if (fileName.startsWith('/')) {
+							String relPath = new File(dir).toURI().relativize(new File(fileName.trim()).toURI()).getPath()
+							fileList.add(relPath);
+						}
+					}
+					return FileVisitResult.CONTINUE;
+				}
+			});
+	return fileList;
+}

--- a/repositoryPathsMapping.yaml
+++ b/repositoryPathsMapping.yaml
@@ -1,6 +1,8 @@
 repositoryPaths:
   - repositoryPath: $application/src/cobol
     artifactsType: "Program"
+    sourceGroup: "cobol"
+    languageProcessor: "Cobol.groovy"
     fileExtension: cbl
     toLowerCase: true
     encoding: IBM-1047
@@ -13,6 +15,8 @@ repositoryPaths:
           - CBLCICS
   - repositoryPath: $application/src/cobol
     artifactsType: "Program"
+    sourceGroup: "cobol"
+    languageProcessor: "Cobol.groovy"
     fileExtension: cbl
     toLowerCase: true
     encoding: IBM-1047
@@ -24,6 +28,8 @@ repositoryPaths:
           - CBLCICS
   - repositoryPath: $application/src/copy
     artifactsType: "Include File"
+    sourceGroup: "copy"
+    languageProcessor: "none"
     fileExtension: cpy
     toLowerCase: true
     encoding: IBM-1047
@@ -32,6 +38,8 @@ repositoryPaths:
         - COPY
   - repositoryPath: $application/src/pli
     artifactsType: "Program"
+    sourceGroup: "pli"
+    languageProcessor: "PLI.groovy"
     fileExtension: cbl
     toLowerCase: true
     encoding: IBM-1047
@@ -43,6 +51,8 @@ repositoryPaths:
         - PLICICS
   - repositoryPath: $application/src/asm
     artifactsType: "Program"
+    sourceGroup: "asm"
+    languageProcessor: "Assembler.groovy"
     fileExtension: asm
     toLowerCase: true
     encoding: IBM-1047
@@ -51,6 +61,8 @@ repositoryPaths:
         - ASM
   - repositoryPath: $application/src/bms
     artifactsType: "Program"
+    sourceGroup: "bms"
+    languageProcessor: "BMS.groovy"
     fileExtension: bms
     toLowerCase: true
     encoding: IBM-1047
@@ -59,6 +71,8 @@ repositoryPaths:
         - BMS
   - repositoryPath: $application/src/link
     artifactsType: "Other"
+    sourceGroup: "link"
+    languageProcessor: "LinkEdit.groovy"
     fileExtension: lnk
     toLowerCase: true
     encoding: IBM-1047

--- a/scanApplication.groovy
+++ b/scanApplication.groovy
@@ -102,6 +102,7 @@ def parseArgs(String[] args) {
 	def cli = new CliBuilder(usage:usage)
 	// required sandbox options
 	cli.w(longOpt:'workspace', args:1, 'Absolute path to workspace (root) directory containing all required source directories')
+	cli.m(longOpt:'metadatastore', args:1, 'Absolute path to DBB Metadatastore used by the modeler')
 	cli.a(longOpt:'application', args:1, required:true, 'Application  name ')
 	cli.l(longOpt:'logFile', args:1, required:false, 'Relative or absolute path to an output log file')
 
@@ -111,6 +112,7 @@ def parseArgs(String[] args) {
 	}
 
 	if (opts.w) props.workspace = opts.w
+	if (opts.m) props.metadatastore = opts.m
 	if (opts.a) props.application = opts.a
 	if (opts.l) {
 		props.logFile = opts.l
@@ -130,7 +132,7 @@ def initScriptParameters() {
 		System.exit(1)
 	}
 	
-	metadataStore = MetadataStoreFactory.createFileMetadataStore("${props.workspace}/.dbb")
+	metadataStore = MetadataStoreFactory.createFileMetadataStore("${props.metadatastore}")
 }
 
 /*

--- a/utils/applicationDescriptorUtils.groovy
+++ b/utils/applicationDescriptorUtils.groovy
@@ -219,6 +219,26 @@ def addApplicationConsumer(ApplicationDescriptor applicationDescriptor, String c
 	} 
 }
 
+/**
+ * Method to drop the source entries
+ */
+
+def resetAllSourceGroups(ApplicationDescriptor applicationDescriptor) {
+	applicationDescriptor.sources = new ArrayList<Source>()
+}
+
+/**
+ * Method to drop the source entries
+ */
+
+def resetConsumersAndDependencies(ApplicationDescriptor applicationDescriptor) {
+	applicationDescriptor.consumers = new ArrayList<Source>()
+	applicationDescriptor.dependencies = new ArrayList<Source>()
+}
+
+/**
+ * Method to create an empty application descriptor object 
+ */
 def createEmptyApplicationDescriptor(){
     ApplicationDescriptor applicationDescriptor = new ApplicationDescriptor()
     applicationDescriptor.sources = new ArrayList<Source>()


### PR DESCRIPTION
This is delivering a new feature to the dbb-git-migration-modeler to allow the re-generate Application Descriptor files for changed/updated Git repositories.