### PR TITLE
Added close instructions for some files

### DIFF
--- a/src/groovy/extractApplications.groovy
+++ b/src/groovy/extractApplications.groovy
@@ -72,6 +72,7 @@ if (props.repositoryPathsMappingFilePath) {
 		logger.logMessage "*! [WARNING] File ${props.repositoryPathsMappingFilePath} not found. Process will exit."
 		System.exit(1)
 	} else {
+		
 		def yamlSlurper = new groovy.yaml.YamlSlurper()
 		repositoryPathsMapping = yamlSlurper.parse(repositoryPathsMappingFile)
 	}
@@ -496,6 +497,7 @@ def loadMapFromFile(String filePath) {
 				map.put(key, value);
 			}
 		}
+		reader.close()
 	} catch (IOException e) {
 		e.printStackTrace();
 	}

--- a/src/groovy/generateProperties.groovy
+++ b/src/groovy/generateProperties.groovy
@@ -49,7 +49,7 @@ def typesConfigurations
 logger.logMessage ("** Reading the Types Configurations definitions from '${props.typesConfigurationsFilePath}'. ")
 def typesConfigurationsFile = new File(props.typesConfigurationsFilePath)
 if (!typesConfigurationsFile.exists()) {
-	logger.logMessage "!* Error: the Types Configurations file '${props.typesConfigurationsFilePath}' doesn't exist. Exiting."
+	logger.logMessage "!* [ERROR] the Types Configurations file '${props.typesConfigurationsFilePath}' doesn't exist. Exiting."
 	System.exit(1);	
 } else {
 	def yamlSlurper = new groovy.yaml.YamlSlurper()
@@ -61,7 +61,7 @@ applicationDescriptorFile = new File("${props.workspace}/${props.application}/ap
 if (applicationDescriptorFile.exists()) {
 	applicationDescriptor = applicationDescriptorUtils.readApplicationDescriptor(applicationDescriptorFile)
 } else {
-	logger.logMessage ("!* Application Descriptor file ${applicationDescriptorFile.getPath()} was not found. Exiting.")
+	logger.logMessage ("!* [ERROR] Application Descriptor file '${applicationDescriptorFile.getPath()}' was not found. Exiting.")
 	System.exit(1)
 }
 
@@ -70,10 +70,10 @@ def customZAppBuildFolderPath = props.workspace + "/dbb-zappbuild"
 // Path of the original dbb-zAppBuild instance got from the script parms
 def originalZAppBuildFolder = new File(props.zAppBuildFolderPath)
 if (!originalZAppBuildFolder.exists()) {
-	logger.logMessage "!* Error: the original dbb-zAppBuild folder '${props.zAppBuildFolderPath}' doesn't exist. Exiting."
+	logger.logMessage "!* [ERROR] The original dbb-zAppBuild folder '${props.zAppBuildFolderPath}' doesn't exist. Exiting."
 	System.exit(1);	
 } else if (!originalZAppBuildFolder.isDirectory()) {
-	logger.logMessage "!* Error: the path '${props.zAppBuildFolderPath}' doesn't point to a folder. Exiting."
+	logger.logMessage "!* [ERROR] The path '${props.zAppBuildFolderPath}' doesn't point to a folder. Exiting."
 	System.exit(1);	
 } else {
 	// Copying the original zAppBuild to the customer instance if it doesn't exist
@@ -105,10 +105,10 @@ if (!applicationConfFolder.exists()) {
 
 // languageConfigurationMapping file
 def languageConfigurationMappingFilePath = applicationConfFolderPath + "/languageConfigurationMapping.properties"
-File languageConfigurationMappingFile = new File(languageConfigurationMappingFilePath)
+/*File languageConfigurationMappingFile = new File(languageConfigurationMappingFilePath)
 if (!languageConfigurationMappingFile.exists()) {
 	languageConfigurationMappingFile.createNewFile()
-}
+} */
 
 def filePropertiesFilePath = applicationConfFolderPath + "/file.properties"
 
@@ -192,6 +192,7 @@ if (filesToLanguageConfigurationMap.size() > 0) {
 			newFilePropertiesWriter.write(line + "\n")
 		}
 	}
+	filePropertiesReader.close()
 
 	// Append new line
 	def currentDate = new Date()
@@ -211,7 +212,6 @@ if (filesToLanguageConfigurationMap.size() > 0) {
 		
 	logger.logMessage("** INFO: Don't forget to enable the use of Language Configuration by uncommenting the 'loadLanguageConfigurationProperties' property in '$filePropertiesFilePath'")
 }
-
 
 // close logger file
 logger.close()

--- a/src/groovy/recreateApplicationDescriptor.groovy
+++ b/src/groovy/recreateApplicationDescriptor.groovy
@@ -155,18 +155,18 @@ def parseArgs(String[] args) {
 def getFileList(String dir) {
 	Set<String> fileList = new HashSet();
 	Files.walkFileTree(Paths.get(dir), new SimpleFileVisitor<Path>() {
-				@Override
-				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-					if (!Files.isDirectory(file)) {
+		@Override
+		public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+			if (!Files.isDirectory(file)) {
 
-						String fileName = file.toString();
-						if (fileName.startsWith('/')) {
-							String relPath = new File(dir).toURI().relativize(new File(fileName.trim()).toURI()).getPath()
-							fileList.add(relPath);
-						}
-					}
-					return FileVisitResult.CONTINUE;
+				String fileName = file.toString();
+				if (fileName.startsWith('/')) {
+					String relPath = new File(dir).toURI().relativize(new File(fileName.trim()).toURI()).getPath()
+					fileList.add(relPath);
 				}
-			});
+			}
+			return FileVisitResult.CONTINUE;
+		}
+	});
 	return fileList;
 }

--- a/src/groovy/utils/applicationDescriptorUtils.groovy
+++ b/src/groovy/utils/applicationDescriptorUtils.groovy
@@ -102,6 +102,7 @@ def writeApplicationDescriptor(File yamlFile, ApplicationDescriptor applicationD
     yamlFile.withWriter("IBM-1047") { writer ->
         writer.write(yamlBuilder.toString())
     }
+    
 	Process process = "chtag -tc IBM-1047 ${yamlFile.getAbsolutePath()}".execute()
 	process.waitFor()   
 }
@@ -345,9 +346,6 @@ def addBaseline(ApplicationDescriptor applicationDescriptor, String branch, Stri
 		applicationDescriptor.baselines = new ArrayList<Baseline>()
 	}
 
-	if (applicationDescriptor.baselines) {
-		applicationDescriptor.sources = new ArrayList<Source>()
-	}
 	Baseline newBaseline = new Baseline()
 	newBaseline.branch = branch
 	newBaseline.baseline = baseline

--- a/src/groovy/utils/applicationsMappingUtils.groovy
+++ b/src/groovy/utils/applicationsMappingUtils.groovy
@@ -25,20 +25,6 @@ class ApplicationsMapping {
 	ArrayList<ApplicationMapping> applications
 }
 
-/////// Test
-//ApplicationsMapping applicationsMapping = readApplicationsMapping(new File("applicationsMapping.yml"))
-//println applicationsMapping.applications
-//println applicationDescriptor.description
-//println applicationDescriptor.sources.size()
-//
-//applicationDescriptor = appendFileDefinition(applicationDescriptor, "copy", "none", "COPY", "COPYBOOK", "PRIVATE")
-//
-//println applicationDescriptor.application
-//println applicationDescriptor.description
-//println applicationDescriptor.sources.size()
-//
-//writeApplicationDescriptor(new File("/u/dbehm/componentization/work/retirementCalculator.yaml"), applicationDescriptor)
-
 /**
  * 
  * Reads an existing application descriptor YAML
@@ -60,9 +46,6 @@ def writeApplicationsMapping(File yamlFile, ApplicationsMapping applicationsMapp
 	yamlBuilder {
 		applications applicationsMapping
 	}
-
-	// debug
-	// println yamlBuilder.toString()
 
 	// write file
 	yamlFile.withWriter() { writer ->

--- a/src/groovy/utils/zappUtils.groovy
+++ b/src/groovy/utils/zappUtils.groovy
@@ -140,7 +140,7 @@ def writeZAppFile(File yamlFile) {
     // write file
     yamlFile.withWriter("IBM-1047") { writer ->
         writer.write(yamlBuilder.toString())
-    } 
+    }
 
 	Process process = "chtag -tc IBM-1047 ${yamlFile.getAbsolutePath()}".execute()
 	process.waitFor()   


### PR DESCRIPTION
The PR implements a set of close instructions for some files that are opened as input or output. Leaving the streams unclosed could lead to keeping the file opened.
It also do some cleanup, and remove unnecessary instructions in the management of baselines in the AD file, as reported by a customer.