### PR TITLE
Add logic to skip program scanning on CONTROL_TRANFERS flag

### DIFF
--- a/src/groovy/assessUsage.groovy
+++ b/src/groovy/assessUsage.groovy
@@ -514,7 +514,7 @@ def parseArgs(String[] args) {
     if (configuration.SCAN_CONTROL_TRANSFERS) {
         props.SCAN_CONTROL_TRANSFERS = configuration.SCAN_CONTROL_TRANSFERS
     } else {
-        logger.logMessage("*! [ERROR] The Scan Control Transfers parameter must be specified in the DBB Git Migration Modeler Configuration file. Exiting.")
+        logger.logMessage("*! [ERROR] The Scan Control Transfers parameter (SCAN_CONTROL_TRANSFERS) must be specified in the DBB Git Migration Modeler Configuration file. Exiting.")
         System.exit(1)
     }
 

--- a/src/groovy/scanApplication.groovy
+++ b/src/groovy/scanApplication.groovy
@@ -220,7 +220,7 @@ def parseArgs(String[] args) {
     if (configuration.SCAN_CONTROL_TRANSFERS) {
         props.SCAN_CONTROL_TRANSFERS = configuration.SCAN_CONTROL_TRANSFERS
     } else {
-        logger.logMessage("*! [ERROR] The Scan Control Transfers parameter must be specified in the DBB Git Migration Modeler Configuration file. Exiting.")
+        logger.logMessage("*! [ERROR] The Scan Control Transfers parameter (SCAN_CONTROL_TRANSFERS) must be specified in the DBB Git Migration Modeler Configuration file. Exiting.")
         System.exit(1)
     }
 


### PR DESCRIPTION
This PR adds the logic to skip the assessment of programs when the SCAN_CONTROL_TRANSFERS is set to true during the Setup phase. This flag controls if the DBB scanner checks for and reports static calls in the list of dependencies. If disabled, no program calls are reported, thus it is not necessary to perform a usage assessment of the programs during the Assessment phase.
Also, fixing a logic in the scan to take into account this flag during processing of the Configuration file.