### PR TITLE
Added support for ZAPP file for zBuilder

### DIFF
--- a/samples/application-repository-configuration/zapp_template.yaml
+++ b/samples/application-repository-configuration/zapp_template.yaml
@@ -14,22 +14,39 @@ author:
   name: IBM CORPORATION
 
 profiles:
-  - name: dbb-build
+  # User build profile example, requires IBM Dependency-Based Build v3.0.3
+  - name: zBuilder-userbuild
     type: dbb
     settings:
-      application: 
-      command: $DBB_HOME/bin/groovyz
-      buildScriptPath: 
-      buildScriptArgs:
-        - --userBuild
-        - --workspace ${zopeneditor.userbuild.userSettings.dbbWorkspace}
-        - --application ${application}
-        - --hlq ${zopeneditor.userbuild.userSettings.dbbHlq}
-        - --outDir ${zopeneditor.userbuild.userSettings.dbbLogDir}
-        - --verbose
-        - --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties
+      command: "$DBB_HOME/bin/dbb build"
+      lifecycle: user
+      lifecycleArgs:
+        - "--hlq ${dbbHlq}"
+        - "--errPrefix ${errPrefix}" # will be ignored if Advanced Features are not available
       additionalDependencies:
-        - ${application}/application-conf
+        - "dbb-app.yaml"
       logFilePatterns:
-        - ${buildFile.basename}.log
-        - BuildReport.*  
+        - "*.log"
+        - "BuildReport.html"
+        - "*.json"
+
+  # User build profile example, requires IBM Dependency-Based Build v2.x
+  - name: groovyz-userbuild
+    type: dbb
+    settings:
+      application:
+      command: "unset JAVA_OPTS; $DBB_HOME/bin/groovyz"
+      buildScriptPath:
+      buildScriptArgs:
+        - "--userBuild"
+        - "--workspace ${dbbWorkspace}"
+        - "--application ${application}"
+        - "--hlq ${dbbHlq}"
+        - "--outDir ${dbbLogDir}"
+        - "--errPrefix ${errPrefix}" # will be ignored if Advanced Features are not available
+        # - "--dependencyFile ${dependencyFile}" # use with older versions of dbb-zappbuild
+      additionalDependencies:
+        - "${application}/application-conf"
+      logFilePatterns:
+        - "${buildFile.basename}.log"
+        - "BuildReport.*"

--- a/src/groovy/utils/zappUtils.groovy
+++ b/src/groovy/utils/zappUtils.groovy
@@ -24,40 +24,69 @@ import com.ibm.dbb.utils.FileUtils
 
 // Initialization
 parseArgs(args)
- 
-File ZAPPFile = new File(props.ZAPPFilePath)
+
+def ZAPPFilePath = props.DBB_MODELER_APPLICATION_DIR + "/" + props.application + "/zapp.yaml"
+File ZAPPFile = new File(ZAPPFilePath)
 if (!ZAPPFile.exists()) {
-	logger.logMessage("*! [ERROR] The ZAPP file '${props.ZAPPFilePath}' was not found. Exiting.")
-	System.exit(1) 
-}
-File applicationDescriptorFile = new File(props.applicationDescriptorFilePath)
-if (!applicationDescriptorFile.exists()) {
-	logger.logMessage("*! [ERROR] The Application Descriptor file '${props.ApplicationDescriptorFilePath}' was not found. Exiting.")
+	logger.logMessage("*! [ERROR] The ZAPP file '${ZAPPFilePath}' was not found. Exiting.")
 	System.exit(1) 
 }
 
-readZAppFile(ZAPPFile)
+def applicationDescriptorFilePath = props.DBB_MODELER_APPLICATION_DIR + "/" + props.application + "/applicationDescriptor.yml"
+File applicationDescriptorFile = new File(applicationDescriptorFilePath)
+if (!applicationDescriptorFile.exists()) {
+	logger.logMessage("*! [ERROR] The Application Descriptor file '${applicationDescriptorFilePath}' was not found. Exiting.")
+	System.exit(1) 
+}
+
+zapp = readZAppFile(ZAPPFile)
 applicationDescriptor = applicationDescriptorUtils.readApplicationDescriptor(applicationDescriptorFile)
 
 zapp.name = "${applicationDescriptor.application}"
 zapp.description = "ZAPP file for the ${applicationDescriptor.application} application"
-def dbbBuildProfile = zapp.profiles.find() { profile ->
-	profile.name.equals("dbb-build")
-}
-if (dbbBuildProfile) {
-	dbbBuildProfile.settings.application = "${applicationDescriptor.application}"
-	dbbBuildProfile.settings.buildScriptPath = "${props.buildScriptPath}"
-}
 
-def includeFilesSourceGroups = applicationDescriptor.sources.findAll() { source ->
-	source.artifactsType.equals("Include File")
-}
-
-if (includeFilesSourceGroups) {
-	includeFilesSourceGroups.each() { includeFilesSourceGroup ->
-		def propertyGroup = addPropertyGroup(includeFilesSourceGroup.name, includeFilesSourceGroup.language)
-		addLibrayToPropertyGroup(propertyGroup, "syslib", "local", includeFilesSourceGroup.repositoryPath)	 
-	}
+if (props.BUILD_FRAMEWORK.equals("zBuilder")) {
+    def includeFilesSourceGroups = applicationDescriptor.sources.findAll() { source ->
+        source.artifactsType.equals("Include File")
+    }
+    
+    if (includeFilesSourceGroups) {
+        includeFilesSourceGroups.each() { includeFilesSourceGroup ->
+            def propertyGroup = addPropertyGroup(includeFilesSourceGroup.name, includeFilesSourceGroup.language)
+            addLibrayToPropertyGroup(propertyGroup, "syslib", "local", includeFilesSourceGroup.repositoryPath)   
+        }
+    }
+    def groovyzBuildProfile = zapp.profiles.find() { profile ->
+        profile.name.equals("groovyz-userbuild")
+    }
+    if (groovyzBuildProfile) {
+        zapp.profiles.removeElement(groovyzBuildProfile)
+    }
+} else if (props.BUILD_FRAMEWORK.equals("zAppBuild")) {
+    def groovyzBuildProfile = zapp.profiles.find() { profile ->
+        profile.name.equals("groovyz-userbuild")
+    }
+    if (groovyzBuildProfile) {
+        groovyzBuildProfile.settings.application = "${applicationDescriptor.application}"
+        groovyzBuildProfile.settings.buildScriptPath = "${props.DBB_ZAPPBUILD}"
+    }
+    
+    def includeFilesSourceGroups = applicationDescriptor.sources.findAll() { source ->
+        source.artifactsType.equals("Include File")
+    }
+    
+    if (includeFilesSourceGroups) {
+        includeFilesSourceGroups.each() { includeFilesSourceGroup ->
+            def propertyGroup = addPropertyGroup(includeFilesSourceGroup.name, includeFilesSourceGroup.language)
+            addLibrayToPropertyGroup(propertyGroup, "syslib", "local", includeFilesSourceGroup.repositoryPath)   
+        }
+    }
+    def zBuilderProfile = zapp.profiles.find() { profile ->
+        profile.name.equals("zBuilder-userbuild")
+    }
+    if (zBuilderProfile) {
+        zapp.profiles.removeElement(zBuilderProfile)
+    }
 }
 
 writeZAppFile(ZAPPFile)
@@ -68,15 +97,13 @@ logger.close()
  * Parse CLI config
  */
 def parseArgs(String[] args) {
-
+    Properties configuration = new Properties()
 	String usage = 'zappUtils.groovy [options]'
-
-	def cli = new CliBuilder(usage:usage)
-	// required sandbox options
-	cli.z(longOpt:'zapp', args:1, 'Absolute path to the ZAPP file')
-	cli.a(longOpt:'applicationDescriptor', args:1, 'Absolute path to the application\'s Application Descriptor file')
-	cli.b(longOpt:'buildScriptPath', args:1, 'Absolute path to the Build Script framework (dbb-zappbuild)')
-	cli.l(longOpt:'logFile', args:1, required:false, 'Relative or absolute path to an output log file')
+    String header = 'options:'
+	def cli = new CliBuilder(usage:usage, header:header)
+    cli.a(longOpt:'application', args:1, required:true, 'Application name.')
+    cli.l(longOpt:'logFile', args:1, required:false, 'Relative or absolute path to an output log file')
+    cli.c(longOpt:'configFile', args:1, required:true, 'Path to the DBB Git Migration Modeler Configuration file (created by the Setup script)')
 
 	def opts = cli.parse(args)
 	if (!opts) {
@@ -87,25 +114,74 @@ def parseArgs(String[] args) {
 		props.logFile = opts.l
 		logger.create(props.logFile)		
 	}
+	
+    if (opts.a) {
+        props.application = opts.a
+    } else {
+        logger.logMessage("*! [ERROR] The Application name (option -a/--application) must be provided. Exiting.")
+        System.exit(1)                     
+    }
 
-	if (opts.z) {
-		props.ZAPPFilePath = opts.z
-	} else {
-		println("*! [ERROR] The path to the ZAPP file must be specified. Exiting.")
-		System.exit(1) 
-	}
-	if (opts.a) {
-		props.applicationDescriptorFilePath = opts.a
-	} else {
-		println("*! [ERROR] The path to the Application Descriptor file must be specified. Exiting.")
-		System.exit(1) 
-	}
-	if (opts.b) {
-		props.buildScriptPath = opts.b
-	} else {
-		println("*! [ERROR] The path to the Build Script framework must be specified. Exiting.")
-		System.exit(1) 
-	}
+    if (opts.c) {
+        props.configurationFilePath = opts.c
+        File configurationFile = new File(props.configurationFilePath)
+        if (configurationFile.exists()) {
+            configurationFile.withReader() { reader ->
+                configuration.load(reader)
+            }
+        } else {
+            logger.logMessage("*! [ERROR] The DBB Git Migration Modeler Configuration file '${opts.c}' does not exist. Exiting.")
+            System.exit(1)                     
+        }
+    } else {
+        logger.logMessage("*! [ERROR] The path to the DBB Git Migration Modeler Configuration file was not specified ('-c/--configFile' parameter). Exiting.")
+        System.exit(1)
+    }
+
+    if (configuration.DBB_MODELER_APPLICATION_DIR) {
+        File directory = new File(configuration.DBB_MODELER_APPLICATION_DIR)
+        if (directory.exists()) {
+            props.DBB_MODELER_APPLICATION_DIR = configuration.DBB_MODELER_APPLICATION_DIR
+        } else {
+            logger.logMessage("*! [ERROR] The Application's directory '${configuration.DBB_MODELER_APPLICATION_DIR}' does not exist. Exiting.")
+            System.exit(1)
+        }
+    } else {
+        logger.logMessage("*! [ERROR] The Applications directory must be specified in the DBB Git Migration Modeler Configuration file. Exiting.")
+        System.exit(1)
+    }
+
+    if (configuration.BUILD_FRAMEWORK) {
+        props.BUILD_FRAMEWORK = configuration.BUILD_FRAMEWORK
+        if (props.BUILD_FRAMEWORK.equals("zBuilder")) {
+            File directory = new File(configuration.DBB_ZBUILDER)
+            if (directory.exists()) {
+                props.DBB_ZBUILDER = configuration.DBB_ZBUILDER
+            } else {
+                logger.logMessage("*! [ERROR] The DBB zBuilder instance '${configuration.DBB_ZBUILDER}' does not exist. Exiting.")
+                System.exit(1)
+            }
+        } else if (props.BUILD_FRAMEWORK.equals("zAppBuild")) {
+            File directory = new File(configuration.DBB_ZAPPBUILD)
+            if (directory.exists()) {
+                props.DBB_ZAPPBUILD = configuration.DBB_ZAPPBUILD
+            } else {
+                logger.logMessage("*! [ERROR] The DBB zAppBuild instance '${configuration.DBB_ZAPPBUILD}' does not exist. Exiting.")
+                System.exit(1)
+            }
+        } else {
+            logger.logMessage("*! [ERROR] The DBB Framework can only be 'zBuilder' or 'zAppBuild' The '${configuration.BUILD_FRAMEWORK}' value defined in the DBB Git Migration Modeler Configuration file is invalid. Exiting.")
+            System.exit(1)
+        }
+    } else {
+        logger.logMessage("*! [ERROR] The DBB Build Framework must be specified in the DBB Git Migration Modeler Configuration file. Exiting.")
+        System.exit(1)
+    }
+
+    logger.logMessage("** Script configuration:")
+    props.each() { k, v ->
+        logger.logMessage("\t$k -> $v")
+    }
 }
 
 
@@ -129,10 +205,10 @@ class ZAppPropertyGroupLibrary {
 def readZAppFile(File yamlFile) {
     // Internal objects
     def yamlSlurper = new groovy.yaml.YamlSlurper()
-    zapp = yamlSlurper.parse(yamlFile)
 	yamlFile.withReader("UTF-8") { reader ->
-		zapp = yamlSlurper.parse(reader)
+		zappFileContent = yamlSlurper.parse(reader)
 	}
+	return zappFileContent
 }
 
 /**

--- a/src/scripts/utils/5-initApplicationRepositories.sh
+++ b/src/scripts/utils/5-initApplicationRepositories.sh
@@ -132,9 +132,9 @@ if [ $rc -eq 0 ]; then
 					echo "[CMD] ${CMD}" >>$DBB_MODELER_LOGS/5-$applicationDir-initApplicationRepository.log
 					$CMD >>$DBB_MODELER_LOGS/5-$applicationDir-initApplicationRepository.log
 					CMD="$DBB_HOME/bin/groovyz $DBB_MODELER_HOME/src/groovy/utils/zappUtils.groovy \
-					-z $DBB_MODELER_APPLICATION_DIR/$applicationDir/zapp.yaml \
-					-a $DBB_MODELER_APPLICATION_DIR/$applicationDir/applicationDescriptor.yml \
-					-b $DBB_ZAPPBUILD -l $DBB_MODELER_LOGS/5-$applicationDir-initApplicationRepository.log"
+					-c $DBB_GIT_MIGRATION_MODELER_CONFIG_FILE \
+					-a $applicationDir \
+					-l $DBB_MODELER_LOGS/5-$applicationDir-initApplicationRepository.log"
 					echo "[CMD] ${CMD}" >>$DBB_MODELER_LOGS/5-$applicationDir-initApplicationRepository.log
 					$CMD
 					rc=$?


### PR DESCRIPTION
This PR adds the support for the correct generation of ZAPP files using zBuilder. It also streamlines the call to the zappUtils utility script, by passing the configuration file instead of one-by-one parameters.
The ZAPP template file is also updated from the zopeneditor repository.