### PR TITLE
Added check for runMigration script

### DIFF
--- a/src/scripts/utils/2-runMigrations.sh
+++ b/src/scripts/utils/2-runMigrations.sh
@@ -76,6 +76,7 @@ if [ $rc -eq 0 ]; then
     ls *.mapping
     rc=$?
     if [ $rc -ne 0 ]; then
+        echo "[ERROR] No DBB Migration Utility mapping file was found. Please check the extraction phase log and check for any error. rc="$rc
         exit $rc
     fi
 

--- a/src/scripts/utils/2-runMigrations.sh
+++ b/src/scripts/utils/2-runMigrations.sh
@@ -73,6 +73,12 @@ if [ $rc -eq 0 ]; then
     APPLICATION_FILTER=",${APPLICATION_FILTER},"
 
 	cd $DBB_MODELER_APPCONFIG_DIR
+    ls *.mapping
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        exit $rc
+    fi
+
     for mappingFile in `ls *.mapping`
     do
         application=`echo $mappingFile | awk -F. '{ print $1 }'`


### PR DESCRIPTION
Added a check that prevents the script to break when no mapping file are generated from the previous step (likely due to a misconfiguration in Applications Mappings files).