### PR TITLE
Remove File Metadatastore from the work folder

### DIFF
--- a/src/scripts/Migration-Modeler-Start.sh
+++ b/src/scripts/Migration-Modeler-Start.sh
@@ -119,6 +119,12 @@ if [ $rc -eq 0 ]; then
             rm -rf $DBB_MODELER_BUILD_CONFIGURATION
             echo "[INFO] Removed '${DBB_MODELER_BUILD_CONFIGURATION}' folder"
         fi
+		if [ "$DBB_MODELER_METADATASTORE_TYPE" == "file"] ;
+			if [ -d $DBB_MODELER_FILE_METADATA_STORE_DIR ]; then
+				rm -rf $DBB_MODELER_FILE_METADATA_STORE_DIR
+				echo "[INFO] Removed '${DBB_MODELER_FILE_METADATA_STORE_DIR}' folder"
+			fi
+		fi
 	fi
 fi
 

--- a/src/scripts/Migration-Modeler-Start.sh
+++ b/src/scripts/Migration-Modeler-Start.sh
@@ -119,7 +119,7 @@ if [ $rc -eq 0 ]; then
             rm -rf $DBB_MODELER_BUILD_CONFIGURATION
             echo "[INFO] Removed '${DBB_MODELER_BUILD_CONFIGURATION}' folder"
         fi
-		if [ "$DBB_MODELER_METADATASTORE_TYPE" == "file"]; then
+		if [ "$DBB_MODELER_METADATASTORE_TYPE" == "file" ]; then
 			if [ -d $DBB_MODELER_FILE_METADATA_STORE_DIR ]; then
 				rm -rf $DBB_MODELER_FILE_METADATA_STORE_DIR
 				echo "[INFO] Removed '${DBB_MODELER_FILE_METADATA_STORE_DIR}' folder"

--- a/src/scripts/Migration-Modeler-Start.sh
+++ b/src/scripts/Migration-Modeler-Start.sh
@@ -119,7 +119,7 @@ if [ $rc -eq 0 ]; then
             rm -rf $DBB_MODELER_BUILD_CONFIGURATION
             echo "[INFO] Removed '${DBB_MODELER_BUILD_CONFIGURATION}' folder"
         fi
-		if [ "$DBB_MODELER_METADATASTORE_TYPE" == "file"] ;
+		if [ "$DBB_MODELER_METADATASTORE_TYPE" == "file"]; then
 			if [ -d $DBB_MODELER_FILE_METADATA_STORE_DIR ]; then
 				rm -rf $DBB_MODELER_FILE_METADATA_STORE_DIR
 				echo "[INFO] Removed '${DBB_MODELER_FILE_METADATA_STORE_DIR}' folder"


### PR DESCRIPTION
This PR adds the removal of the DBB File MetadataStore at the beginning of the Migration-Modeler-Start.sh script.